### PR TITLE
fix license QA warnings

### DIFF
--- a/meta-ros-common/recipes-devtools/python/python-empy.inc
+++ b/meta-ros-common/recipes-devtools/python/python-empy.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "A powerful and robust templating system for Python"
 SECTION = "devel/python"
-LICENSE = "LGPL-2.1"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=7fbc338309ac38fefcd64b04bb903e34"
 SRCNAME = "empy"
 

--- a/meta-ros-common/recipes-devtools/python/python3-prettytable_0.7.2.bb
+++ b/meta-ros-common/recipes-devtools/python/python3-prettytable_0.7.2.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Python library for displaying tabular data in a ASCII table format"
 HOMEPAGE = "http://code.google.com/p/prettytable"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=3e73500ffa52de5071cff65990055282"
 
 SRC_URI[md5sum] = "0c1361104caff8b09f220748f9d69899"

--- a/meta-ros1-noetic/recipes-ros/orocos-kinematics-dynamics/orocos-kdl_1.4.0.bb
+++ b/meta-ros1-noetic/recipes-ros/orocos-kinematics-dynamics/orocos-kdl_1.4.0.bb
@@ -3,7 +3,7 @@
 require orocos-kdl.inc
 
 DESCRIPTION = "Kinematics and Dynamics Library (KDL), distributed by the Orocos Project."
-LICENSE = "LGPLv2.1"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a8ffd58e6eb29a955738b8fcc9e9e8f2"
 
 S = "${WORKDIR}/git/orocos_kdl"

--- a/meta-ros1-noetic/recipes-ros/orocos-kinematics-dynamics/python3-pykdl_1.4.0.bb
+++ b/meta-ros1-noetic/recipes-ros/orocos-kinematics-dynamics/python3-pykdl_1.4.0.bb
@@ -4,7 +4,7 @@ require orocos-kdl.inc
 
 DESCRIPTION = "The python bindings PyKDL for the Kinematics and Dynamics Library (KDL), distributed by the Orocos Project."
 SECTION = "devel"
-LICENSE = "LGPLv2.1+"
+LICENSE = "LGPL-2.1-or-later"
 #LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=11;endline=11;md5=27620a6c8e31b44ce8d87ab1e2127522"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=46ee8693f40a89a31023e97ae17ecf19"
 

--- a/meta-ros1/recipes-extended/urdfdom-headers/urdfdom-headers_1.0.0-1.bb
+++ b/meta-ros1/recipes-extended/urdfdom-headers/urdfdom-headers_1.0.0-1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "The URDF (U-Robot Description Format) headers provides core \
 data structure headers for URDF."
 SECTION = "devel"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b441202ba2d6b14d62026cb18bb960ed"
 
 ROS_BPN = "urdfdom_headers"


### PR DESCRIPTION
Move python-empy, orocos-kdl and python3-pykdl
to LGPL-2.1-or-later

Move python3-prettytable and urdffom-headers
to BSD-3-Clause