### PR TITLE
rosbash: don't hack bash

### DIFF
--- a/meta-ros1-noetic/recipes-bbappends/ros/rosbash_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/rosbash_%.bbappend
@@ -1,9 +1,13 @@
 # Copyright (c) 2019 LG Electronics, Inc.
 
+PACKAGECONFIG ??= "bash-real"
+
 # "rosrun" uses array variables, so we can't use the BASH provided by "busybox" but must use a "real" one. NB. "busybox" is only
 # present on the target.
 do_install:append:class-target() {
-    sed -i -e '1 s@^.*$@#!/usr/bin/env bash-real@' ${D}${ros_bindir}/rosrun
+    if ${@bb.utils.contains('PACKAGECONFIG', 'bash-real', 'true', 'false', d)}; then
+        sed -i -e '1 s@^.*$@#!/usr/bin/env bash-real@' ${D}${ros_bindir}/rosrun
+    fi
 }
 
-RDEPENDS:${PN}:append:class-target = " bash-real"
+RDEPENDS:${PN}:append:class-target = " ${@bb.utils.contains('PACKAGECONFIG', 'bash-real', 'bash-real', '', d)}"


### PR DESCRIPTION
We use the real bash and this just complicates things. Put it under a PACKAGECONFIG that we can disable. This would be difficult to undo from another bbappend so we just do it here.