### PR TITLE
Yoc50 cleanup

### DIFF
--- a/meta-ros-common/conf/ros-distro/ros-distro.conf
+++ b/meta-ros-common/conf/ros-distro/ros-distro.conf
@@ -14,7 +14,7 @@ ROS_DISTRO_COMPAT = "melodic dashing eloquent"
 
 # This variable is updated with the new release series as the first commit to [master] after the branch for the current release
 # series is created.
-ROS_OE_RELEASE_SERIES = "kirkstone"
+ROS_OE_RELEASE_SERIES = "scarthgap"
 
 # "1" or "2"
 ROS_DISTRO_METADATA_VERSION_MAJOR = "${ROS_VERSION}"

--- a/meta-ros-common/recipes-devtools/tvm/tvm_0.7.0.bb
+++ b/meta-ros-common/recipes-devtools/tvm/tvm_0.7.0.bb
@@ -7,18 +7,20 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e313a9b6eda820e35716d9529001537f"
 
 # matches with tag 0.7.0
-SRCREV = "728b829575e5e690870b111ae2256cbe0f3dbe6f"
+SRCREV_release = "728b829575e5e690870b111ae2256cbe0f3dbe6f"
 SRCREV_dlmc-core = "6c401e242c59a1f4c913918246591bb13fd714e7"
 SRCREV_dlpack = "3ec04430e89a6834e5a1b99471f415fa939bf642"
 SRCREV_rang = "cabe04d6d6b05356fa8f9741704924788f0dd762"
 SRCREV_vta-hw = "87ce9acfae550d1a487746e9d06c2e250076e54c"
 
-SRC_URI = "git://github.com/apache/tvm;branch=main;protocol=https \
+SRC_URI = "git://github.com/apache/tvm;name=release;branch=main;protocol=https \
     git://github.com/dmlc/dmlc-core;name=dlmc-core;destsuffix=git/3rdparty/dmlc-core;branch=master;protocol=https \
     git://github.com/dmlc/dlpack;name=dlpack;destsuffix=git/3rdparty/dlpack;branch=master;protocol=https \
     git://github.com/agauniyal/rang;name=rang;destsuffix=git/3rdparty/rang;branch=master;protocol=https \
     git://github.com/apache/incubator-tvm-vta;name=vta-hw;destsuffix=git/3rdparty/vta-hw;branch=master;protocol=https \
 "
+
+SRCREV_FORMAT = "release_dlmc-core_dlpack_rang_vta-hw"
 
 S = "${WORKDIR}/git"
 

--- a/meta-ros-common/recipes-extended/fcl/fcl_0.6.1.bb
+++ b/meta-ros-common/recipes-extended/fcl/fcl_0.6.1.bb
@@ -6,11 +6,13 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=7de20b14c33be61ee0c714b41e286d0b"
 # Octomap dependency not included as it is optional.
 DEPENDS = "boost libccd libeigen"
 
-SRCREV = "97455a46de121fb7c0f749e21a58b1b54cd2c6be"
 ROS_BRANCH ?= "branch=master"
 SRC_URI = " \
-    git://github.com/flexible-collision-library/fcl;${ROS_BRANCH};protocol=https \
+    git://github.com/flexible-collision-library/fcl;name=release;${ROS_BRANCH};protocol=https \
 "
+SRCREV_release = "97455a46de121fb7c0f749e21a58b1b54cd2c6be"
+
+SRCREV_FORMAT = "release"
 
 S = "${WORKDIR}/git"
 

--- a/meta-ros-common/recipes-support/lcov/lcov_1.14.bbappend
+++ b/meta-ros-common/recipes-support/lcov/lcov_1.14.bbappend
@@ -1,4 +1,0 @@
-# Copyright (c) 2020 LG Electronics, Inc.
-
-# Backport https://lists.openembedded.org/g/openembedded-devel/message/86162
-RDEPENDS:${PN}:remove:class-native = "gcov gcov-symlinks"

--- a/meta-ros1-noetic/conf/layer.conf
+++ b/meta-ros1-noetic/conf/layer.conf
@@ -21,6 +21,6 @@ LAYERDEPENDS_ros1-noetic-layer = " \
     ros1-layer \
 "
 
-LAYERSERIES_COMPAT_ros1-noetic-layer = "${ROS_OE_RELEASE_SERIES}"
+LAYERSERIES_COMPAT_ros1-noetic-layer = "scarthgap"
 
 require conf/ros-distro/include/noetic/ros-distro.inc

--- a/meta-ros1-noetic/generated-recipes/darknet-ros/darknet-ros_1.1.5-1.bb
+++ b/meta-ros1-noetic/generated-recipes/darknet-ros/darknet-ros_1.1.5-1.bb
@@ -91,8 +91,9 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/leggedrobotics/darknet_ros-release/archive/release/noetic/darknet_ros/1.1.5-1.tar.gz
 ROS_BRANCH ?= "branch=release/noetic/darknet_ros"
-SRC_URI = "git://github.com/leggedrobotics/darknet_ros-release;${ROS_BRANCH};protocol=https"
-SRCREV = "9f448396ffa31cb6e4383de6205ac4025436fdf3"
+SRC_URI = "git://github.com/leggedrobotics/darknet_ros-release;name=release;${ROS_BRANCH};protocol=https"
+SRCREV_release = "9f448396ffa31cb6e4383de6205ac4025436fdf3"
+SRCREV_FORMAT = "release"
 S = "${WORKDIR}/git"
 
 ROS_BUILD_TYPE = "catkin"

--- a/meta-ros1-noetic/generated-recipes/fmi-adapter/fmi-adapter_1.0.4-1.bb
+++ b/meta-ros1-noetic/generated-recipes/fmi-adapter/fmi-adapter_1.0.4-1.bb
@@ -54,9 +54,10 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/boschresearch/fmi_adapter-release/archive/release/noetic/fmi_adapter/1.0.4-1.tar.gz
 ROS_BRANCH ?= "branch=release/noetic/fmi_adapter"
-SRC_URI = "git://github.com/boschresearch/fmi_adapter-release;${ROS_BRANCH};protocol=https"
-SRCREV = "ebabc0691f1083e87d45e2199032550cc6a6646a"
+SRC_URI = "git://github.com/boschresearch/fmi_adapter-release;name=release;${ROS_BRANCH};protocol=https"
+SRCREV_release = "ebabc0691f1083e87d45e2199032550cc6a6646a"
 S = "${WORKDIR}/git"
+SRCREV_FORMAT = "release"
 
 ROS_BUILD_TYPE = "catkin"
 

--- a/meta-ros1-noetic/generated-recipes/jsk-3rdparty/libcmt_2.1.21-2.bb
+++ b/meta-ros1-noetic/generated-recipes/jsk-3rdparty/libcmt_2.1.21-2.bb
@@ -48,8 +48,9 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/libcmt/2.1.21-2.tar.gz
 ROS_BRANCH ?= "branch=release/noetic/libcmt"
-SRC_URI = "git://github.com/tork-a/jsk_3rdparty-release;${ROS_BRANCH};protocol=https"
-SRCREV = "9264913546e8541119aefc4ddb7f7b955ebe40a1"
+SRC_URI = "git://github.com/tork-a/jsk_3rdparty-release;name=release;${ROS_BRANCH};protocol=https"
+SRCREV_release = "9264913546e8541119aefc4ddb7f7b955ebe40a1"
+SRCREV_FORMAT = "release"
 S = "${WORKDIR}/git"
 
 ROS_BUILD_TYPE = "cmake"

--- a/meta-ros1-noetic/generated-recipes/jsk-3rdparty/slic_2.1.21-2.bb
+++ b/meta-ros1-noetic/generated-recipes/jsk-3rdparty/slic_2.1.21-2.bb
@@ -51,9 +51,10 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/tork-a/jsk_3rdparty-release/archive/release/noetic/slic/2.1.21-2.tar.gz
 ROS_BRANCH ?= "branch=release/noetic/slic"
-SRC_URI = "git://github.com/tork-a/jsk_3rdparty-release;${ROS_BRANCH};protocol=https"
-SRCREV = "eaf1f04cb1e6a47c05d599f057688e9d655993bc"
+SRC_URI = "git://github.com/tork-a/jsk_3rdparty-release;name=release;${ROS_BRANCH};protocol=https"
+SRCREV_release = "eaf1f04cb1e6a47c05d599f057688e9d655993bc"
 S = "${WORKDIR}/git"
+SRCREV_FORMAT = "release"
 
 ROS_BUILD_TYPE = "cmake"
 

--- a/meta-ros1-noetic/generated-recipes/osqp-vendor/osqp-vendor_0.1.2-1.bb
+++ b/meta-ros1-noetic/generated-recipes/osqp-vendor/osqp-vendor_0.1.2-1.bb
@@ -42,9 +42,10 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/tier4/osqp_vendor-release/archive/release/noetic/osqp_vendor/0.1.2-1.tar.gz
 ROS_BRANCH ?= "branch=release/noetic/osqp_vendor"
-SRC_URI = "git://github.com/tier4/osqp_vendor-release;${ROS_BRANCH};protocol=https"
-SRCREV = "0bc19f9df13028fed6b03ce0bc3eb1b984dbcbc8"
+SRC_URI = "git://github.com/tier4/osqp_vendor-release;name=release;${ROS_BRANCH};protocol=https"
+SRCREV_release = "0bc19f9df13028fed6b03ce0bc3eb1b984dbcbc8"
 S = "${WORKDIR}/git"
+SRCREV_FORMAT = "release"
 
 ROS_BUILD_TYPE = "catkin"
 

--- a/meta-ros1-noetic/generated-recipes/pybind11-catkin/pybind11-catkin_2.5.0-1.bb
+++ b/meta-ros1-noetic/generated-recipes/pybind11-catkin/pybind11-catkin_2.5.0-1.bb
@@ -43,9 +43,10 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/wxmerkt/pybind11_catkin-release/archive/release/noetic/pybind11_catkin/2.5.0-1.tar.gz
 ROS_BRANCH ?= "branch=release/noetic/pybind11_catkin"
-SRC_URI = "git://github.com/wxmerkt/pybind11_catkin-release;${ROS_BRANCH};protocol=https"
-SRCREV = "7e675c234b27905894456c8633b829938666610d"
+SRC_URI = "git://github.com/wxmerkt/pybind11_catkin-release;name=release;${ROS_BRANCH};protocol=https"
+SRCREV_release = "7e675c234b27905894456c8633b829938666610d"
 S = "${WORKDIR}/git"
+SRCREV_FORMAT = "release"
 
 ROS_BUILD_TYPE = "catkin"
 

--- a/meta-ros1-noetic/generated-recipes/qpoases-vendor/qpoases-vendor_3.2.1-1.bb
+++ b/meta-ros1-noetic/generated-recipes/qpoases-vendor/qpoases-vendor_3.2.1-1.bb
@@ -47,9 +47,10 @@ RDEPENDS:${PN} += "${ROS_EXEC_DEPENDS}"
 
 # matches with: https://github.com/autoware-ai/qpoases_vendor-release/archive/release/noetic/qpoases_vendor/3.2.1-1.tar.gz
 ROS_BRANCH ?= "branch=release/noetic/qpoases_vendor"
-SRC_URI = "git://github.com/autoware-ai/qpoases_vendor-release;${ROS_BRANCH};protocol=https"
-SRCREV = "37962324bdc1c603d4889b77b2c7389e8d91a01b"
+SRC_URI = "git://github.com/autoware-ai/qpoases_vendor-release;name=release;${ROS_BRANCH};protocol=https"
+SRCREV_release = "37962324bdc1c603d4889b77b2c7389e8d91a01b"
 S = "${WORKDIR}/git"
+SRCREV_FORMAT = "release"
 
 ROS_BUILD_TYPE = "catkin"
 

--- a/meta-ros1-noetic/recipes-bbappends/darknet-ros/darknet-ros_1.1.5-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/darknet-ros/darknet-ros_1.1.5-1.bbappend
@@ -28,6 +28,8 @@ SRC_URI[yolov2-tiny.sha256sum] = "16f4e870f1aed83f0089cb69bfda6b53cb7b2a4a01721b
 SRC_URI[yolov3.sha256sum] = "523e4e69e1d015393a1b0a441cef1d9c7659e3eb2d7e15f793f060a21b32f297"
 SRC_URI[yolov2.sha256sum] = "d9945162ed6f54ce1a901e3ec537bdba4d572ecae7873087bd730e5a7942df3f"
 
+SRCREV_FOMAT .= "_darknet"
+
 do_configure:prepend() {
     # we have used "yolo-${YOLO_RELEASE}-" as a prefix in downloadfilename
     # to make sure files in DL_DIR contain a version (so that they are properly re-downloaded

--- a/meta-ros1-noetic/recipes-bbappends/fcl-catkin/fcl-catkin_0.6.1-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/fcl-catkin/fcl-catkin_0.6.1-1.bbappend
@@ -8,6 +8,7 @@ SRC_URI += "file://0001-CMakeLists.txt-fetch-fcl-with-bitbake-fetcher.patch \
     git://github.com/flexible-collision-library/fcl.git;protocol=https;name=fcl-upstream;destsuffix=git/fcl-upstream;branch=master \
 "
 SRCREV_fcl-upstream = "97455a46de121fb7c0f749e21a58b1b54cd2c6be"
+SRCREV_FORMAT .= "_fcl-upstream"
 
 # WARNING: fcl-catkin-0.6.0-1-r0 do_package: QA Issue: fcl-catkin: Files/directories were installed but not shipped in any package:
 #   /opt/ros/melodic/lib/libfcl.so.0.6

--- a/meta-ros1-noetic/recipes-bbappends/fmi-adapter/fmi-adapter_1.0.4-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/fmi-adapter/fmi-adapter_1.0.4-1.bbappend
@@ -8,3 +8,4 @@ SRC_URI += "file://0001-CMakeLists.txt-fetch-fmi-library-with-bitbake-fetche.pat
     git://github.com/modelon-community/fmi-library.git;protocol=https;name=fmi-library;destsuffix=git/fmi-library-upstream;branch=master \
 "
 SRCREV_fmi-library = "d5ce0b923dd42fbc59b61edb17e837cd148e9501"
+SRCREV_FORMAT .= "_fmi-library"

--- a/meta-ros1-noetic/recipes-bbappends/jsk-3rdparty/libcmt_2.1.21-2.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/jsk-3rdparty/libcmt_2.1.21-2.bbappend
@@ -10,6 +10,7 @@ SRC_URI += "file://0001-CMakeLists.txt-fetch-libcmt-with-bitbake-fetcher.patch \
     git://github.com/delmottea/libCMT.git;protocol=https;name=libcmt-upstream;destsuffix=git/libcmt-upstream;branch=master \
 "
 SRCREV_libcmt-upstream = "e4d7ea42edafe13b1070ef4d595b2d6062d79d1a"
+SRCREV_FORMAT .= "_libcmt-upstream"
 
 # CMakeLists.txt just calls make install in libcmt-ustream, which doesn't work
 # as we're using ninja by default, lets do what cmake.bbclass does, just inside

--- a/meta-ros1-noetic/recipes-bbappends/jsk-3rdparty/slic_2.1.21-2.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/jsk-3rdparty/slic_2.1.21-2.bbappend
@@ -9,3 +9,4 @@ SRC_URI += "file://0001-CMakeLists.txt-fetch-slic-with-bitbake-fetcher.patch \
     file://0001-CMakeLists.txt-add-very-simple-CMake-file.patch;patchdir=slic-upstream \
 "
 SRCREV_slic-upstream = "78d9a2ba7ae1d3fee8c2ec774a52536c5f08f07c"
+SRCREV_FORMAT .= "_slic-upstream"

--- a/meta-ros1-noetic/recipes-bbappends/osqp-vendor/osqp-vendor_0.1.2-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/osqp-vendor/osqp-vendor_0.1.2-1.bbappend
@@ -12,6 +12,7 @@ SRC_URI += "file://0001-CMakeLists.txt-user-relative-destination-path.patch \
 "
 SRCREV_osqp = "f9fc23d3436e4b17dd2cb95f70cfa1f37d122c24"
 SRCREV_qdldl = "7d16b70a10a152682204d745d814b6eb63dc5cd2"
+SRCREV_FORMAT .= "_osqp_qdldl"
 
 # ERROR: osqp-vendor-0.1.2-1-r0 do_package: QA Issue: osqp-vendor: Files/directories were installed but not shipped in any package:
 #   /usr/opt/ros/noetic/lib/cmake

--- a/meta-ros1-noetic/recipes-bbappends/pybind11-catkin/pybind11-catkin_2.5.0-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/pybind11-catkin/pybind11-catkin_2.5.0-1.bbappend
@@ -9,6 +9,7 @@ SRC_URI += "file://0001-CMakeLists.txt-fetch-pybind11-with-bitbake-fetcher.patch
 "
 
 SRCREV_pybind11-upstream = "014cd12ec1a3258f3bfc6597f371ed46c8e89ccd"
+SRCREV_FORMAT .= "_pybind11-upstream"
 
 # Otherwise picks native python instead of the target one and fails with:
 # | Re-run cmake no build system arguments

--- a/meta-ros1-noetic/recipes-bbappends/qpoases-vendor/qpoases-vendor_3.2.1-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/qpoases-vendor/qpoases-vendor_3.2.1-1.bbappend
@@ -10,3 +10,4 @@ SRC_URI += "file://0001-CMakeLists.txt-fetch-qpOASES-with-bitbake-fetcher.patch 
     git://github.com/coin-or/qpOASES;protocol=https;branch=stable/3.2;name=qpOASES-upstream;destsuffix=git/qpOASES-upstream \
 "
 SRCREV_qpOASES-upstream = "4799956d98cb9a5ca32e818c6ef79b69103392d8"
+SRCREV_FORMAT .= "_qpOASES-upstream"

--- a/meta-ros1-noetic/recipes-support/libftdi/libftdi_1.4.bbappend
+++ b/meta-ros1-noetic/recipes-support/libftdi/libftdi_1.4.bbappend
@@ -1,4 +1,0 @@
-# Copyright (c) 2020 LG Electronics, Inc.
-
-# needed for epos2-motor-controller and maybe other recipes
-PACKAGECONFIG += "cpp-wrapper"

--- a/meta-ros1/conf/layer.conf
+++ b/meta-ros1/conf/layer.conf
@@ -20,6 +20,6 @@ LAYERDEPENDS_ros1-layer = " \
     ros-common-layer \
 "
 
-LAYERSERIES_COMPAT_ros1-layer = "${ROS_OE_RELEASE_SERIES}"
+LAYERSERIES_COMPAT_ros1-layer = "scarthgap"
 
 ROS_OE_DISTRO_NAME ?= "Robot Operating System (ROS 1)"


### PR DESCRIPTION
Various changes to get the badger-kirkstone branch building for yocto-5.0

- Hardwired to "scarthgap" since the ROS_OE_RELEASE_SERIES variable wouldn't resolve
- Add SRCREV_FORMAT to various recipes as needed by yocto-5.0
- cherry-pick 2 commits from meta-ros:scarthgap to remove old .bbappend files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/meta-ros/3)
<!-- Reviewable:end -->
