### PR TITLE
Ignore conflicting fuse recipes regardless of version

### DIFF
--- a/meta-ros2-jazzy/conf/ros-distro/include/jazzy/ros-distro-recipe-blacklist.inc
+++ b/meta-ros2-jazzy/conf/ros-distro/include/jazzy/ros-distro-recipe-blacklist.inc
@@ -194,9 +194,9 @@ SKIP_RECIPE[zenoh-bridge-dds] ?= "${@bb.utils.contains_any('ROS_WORLD_SKIP_GROUP
 
 # Renamed to fuse-ros in recipes-bbappends/fuse to avoid conflict with
 # meta-filesystems/recipes-support/fuse/fuse_2.9.9.bb
-BBMASK +=  "generated-recipes/fuse/fuse_1.0.1-3.bb"
+BBMASK +=  "generated-recipes/fuse/fuse_.*\.bb"
 # And renamed fuse-doc to fuse-ros-doc to avoid conflict with PN-doc package created by fuse recipe
-BBMASK +=  "generated-recipes/fuse/fuse-doc_1.0.1-3.bb"
+BBMASK +=  "generated-recipes/fuse/fuse-doc_.*\.bb"
 
 # meta-ros provides a recipe for octomap to use instead of the generated one
 BBMASK +=  "generated-recipes/octomap/octomap_1.10.0-4.bb"


### PR DESCRIPTION
The version was hardcoded into the BBMASK setting but the version had updated meaning the BBMASK was no longer taking effect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/meta-ros/4)
<!-- Reviewable:end -->
